### PR TITLE
v4.3.1.cw1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This extension helps developers to integrate with AfterShip easily.
 AfterShip provides an automated way for online merchants to track packages and send their customers delivery status notifications. Customers no longer need to deal with tracking numbers and track packages on their own. With AfterShip, online merchants extend their customer service after the point of purchase by keeping their customers actively informed, while saving time and money by reducing customers’ questions about the status of their purchase delivery.
 
 ### Changes
+* 2017-12-06 4.3.1.cw1
+  - Remove retry mechanism, including `sleep`ing the thread if request to the API is unsuccessful
+  - Introduced a `Configuration` object that encapsulates any gem configuration, like client `timeout` (in milliseconds), `headers`, `api_key` and `api_endpoint` (that defaults to `api.aftership.com`)
+    - Set the value of `configuration.send_timeout` to `HTTPClient#send_timeout`
+    - Set the value of `configuration.receive_timeout` to `HTTPClient#receive_timeout`
+    - Set the value of `configuration.connect_timeout` to `HTTPClient#connect_timeout`
+    - Set the `configuration.headers` to the request headers
+    - Use the `configuration.api_endpoint` as the main API endpoint for the gem
+
 * 2016-01-11 4.3.1
   - Updated gem `httpclient` version to 2.7.1
 

--- a/aftership.gemspec
+++ b/aftership.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httpclient', '~> 2.7.1'
 
-  s.add_development_dependency 'rspec', '~> 2.14.1'
+  s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'pry'
 end

--- a/lib/aftership.rb
+++ b/lib/aftership.rb
@@ -1,13 +1,20 @@
 $:.unshift File.dirname(__FILE__)
 
+require 'aftership/v4/configuration'
 require 'aftership/v4/courier'
 require 'aftership/v4/tracking'
 require 'aftership/v4/last_checkpoint'
 
 module AfterShip
   class << self;
-    attr_accessor :api_key
+    attr_accessor :configuration
   end
 
-  URL = ENV['AFTERSHIP_API_ENDPOINT'] || 'https://api.aftership.com'
+  def self.configuration
+    @configuration ||= AfterShip::V4::Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
 end

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -29,6 +29,8 @@ module AfterShip
 
         begin
           response = @client.send(http_verb_method, url, parameters)
+          cf_ray = response.headers['CF-RAY']
+
           return JSON.parse(response.body) if response.body
 
           {
@@ -37,7 +39,9 @@ module AfterShip
               :message => 'Something went wrong on AfterShip\'s end.',
               :type => 'InternalError'
             },
-            :data => {}
+            :data => {
+              :cf_ray => cf_ray
+            }
           }
         rescue HTTPClient::SendTimeoutError
           {

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -65,9 +65,8 @@ module AfterShip
       private
 
       def url
-        "#{AfterShip::URL}/v4/#{end_point.to_s}"
+        "#{AfterShip.configuration.api_endpoint}/v4/#{end_point.to_s}"
       end
-
     end
   end
 end

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -14,6 +14,10 @@ module AfterShip
         @query = query
         @body = body
         @client = HTTPClient.new
+
+        if AfterShip.configuration.timeout.present?
+          @client.send_timeout = AfterShip.configuration.timeout
+        end
       end
 
       def call

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -21,13 +21,10 @@ module AfterShip
       end
 
       def call
-
-        header = {'aftership-api-key' => AfterShip.api_key, 'Content-Type' => 'application/json'}
-
         parameters = {
             :query => query,
             :body => body.to_json,
-            :header => header
+            :header => AfterShip.configuration.headers
         }
 
         begin

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -43,6 +43,14 @@ module AfterShip
               :cf_ray => cf_ray
             }
           }
+        rescue HTTPClient::ConnectTimeoutError
+          {
+            :meta => {
+              :code => 408,
+              :message => 'We cannot connect to AfterShip at this moment.',
+              :type => 'ConnectTimeoutError'
+            }
+          }
         rescue HTTPClient::SendTimeoutError
           {
             :meta => {

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -59,6 +59,14 @@ module AfterShip
               :type => 'SendTimeoutError'
             }
           }
+        rescue HTTPClient::ReceiveTimeoutError
+          {
+            :meta => {
+              :code => 503,
+              :message => 'AfterShip is unavailable.',
+              :type => 'ReceiveTimeoutError'
+            }
+          }
         rescue JSON::ParserError
           {
             :meta => {

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -15,9 +15,7 @@ module AfterShip
         @body = body
         @client = HTTPClient.new
 
-        if AfterShip.configuration.timeout.present?
-          @client.send_timeout = AfterShip.configuration.timeout
-        end
+        @client.send_timeout = AfterShip.configuration.timeout
       end
 
       def call

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -15,7 +15,9 @@ module AfterShip
         @body = body
         @client = HTTPClient.new
 
-        @client.send_timeout = AfterShip.configuration.timeout
+        @client.connect_timeout = AfterShip.configuration.connect_timeout
+        @client.send_timeout = AfterShip.configuration.send_timeout
+        @client.receive_timeout = AfterShip.configuration.receive_timeout
       end
 
       def call

--- a/lib/aftership/v4/configuration.rb
+++ b/lib/aftership/v4/configuration.rb
@@ -1,0 +1,28 @@
+module AfterShip
+  module V4
+    class Configuration
+      attr_accessor :api_endpoint, :api_key
+      attr_writer :timeout
+
+      def initialize
+        @api_endpoint = 'https://api.aftership.com'
+        @timeout = 3
+        @headers = { 'Content-Type' => 'application/json' }
+      end
+
+      def timeout
+        return 0 unless @timeout
+
+        @timeout.to_f / 1000
+      end
+
+      def headers
+        @headers.merge('aftership-api-key' => api_key)
+      end
+
+      def headers= h
+        @headers.merge!(h)
+      end
+    end
+  end
+end

--- a/lib/aftership/v4/configuration.rb
+++ b/lib/aftership/v4/configuration.rb
@@ -2,18 +2,25 @@ module AfterShip
   module V4
     class Configuration
       attr_accessor :api_endpoint, :api_key
-      attr_writer :timeout
+      attr_writer :connect_timeout, :send_timeout, :receive_timeout
 
       def initialize
         @api_endpoint = 'https://api.aftership.com'
-        @timeout = 3
         @headers = { 'Content-Type' => 'application/json' }
+        @connect_timeout = @receive_timeout = 500 # milliseconds
+        @send_timeout = 1000 # milliseconds
       end
 
-      def timeout
-        return 0 unless @timeout
+      def connect_timeout
+        to_seconds(@connect_timeout)
+      end
 
-        @timeout.to_f / 1000
+      def send_timeout
+        to_seconds(@send_timeout)
+      end
+
+      def receive_timeout
+        to_seconds(@receive_timeout)
       end
 
       def headers
@@ -22,6 +29,12 @@ module AfterShip
 
       def headers= h
         @headers.merge!(h)
+      end
+
+      private
+
+      def to_seconds(milliseconds)
+        milliseconds.to_f / 1000
       end
     end
   end

--- a/spec/v4/base_spec.rb
+++ b/spec/v4/base_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe AfterShip::V4::Base do
+  subject(:instance) { described_class.new(http_verb_method, end_point, query, body) }
+  let(:client) { HTTPClient.new }
+
+  before do
+    allow(HTTPClient).to receive(:new).and_return(client)
+  end
+
+  let(:http_verb_method) { :get }
+  let(:end_point) { 'endpoint' }
+  let(:query) { {} }
+  let(:body) { {} }
+
+  describe '#call' do
+    subject { instance.call }
+
+    context 'when the response returns an invalid json' do
+      let(:response) { OpenStruct.new(body: 'test', headers: { 'CF-RAY' => cf_ray }) }
+      let(:cf_ray) { 'cf ray' }
+      let(:json_response) do
+        {
+          meta: {
+            code: 500,
+            message: "Something went wrong on AfterShip's end.",
+            type: 'InternalError'
+          },
+          data: {
+            body: 'test',
+            cf_ray: cf_ray
+          }
+        }
+      end
+
+      before do
+        allow(client).to receive_message_chain(:send).and_return(response)
+      end
+
+      it { is_expected.to eq(json_response) }
+    end
+  end
+end


### PR DESCRIPTION
~Not to be merged. We need to review the code here, and open a PR upstream. If the maintainers accept the changes they'll need to bump the version and cut a new gem.~

Since we don't see any development upstream on our PR (but there's a `v5` branch with ongoing development), we need to resort to our own fork of the gem for the time being. When the upstream maintainers get out a new version of the gem, without the current pitfalls/flaws, we can move to the upstream version.

This version of our fork will use the same version as the upstream gem, but we will apply `cw1` as a "teeny" version to it. After merging this PR, I will push a new tag to be used in `cw-shipping`.

Upstream PRs:
- Removal of retry mechanism PR - https://github.com/AfterShip/aftership-sdk-ruby/pull/23