### PR TITLE
Timeout improvements

### DIFF
--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -57,6 +57,14 @@ module AfterShip
               :type => 'SendTimeoutError'
             }
           }
+        rescue HTTPClient::ReceiveTimeoutError
+          {
+            :meta => {
+              :code => 503,
+              :message => 'AfterShip is unavailable.',
+              :type => 'ReceiveTimeoutError'
+            }
+          }
         rescue JSON::ParserError
           {
             :meta => {

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -41,6 +41,14 @@ module AfterShip
             },
             :data => {}
           }
+        rescue HTTPClient::ConnectTimeoutError
+          {
+            :meta => {
+              :code => 408,
+              :message => 'We cannot connect to AfterShip at this moment.',
+              :type => 'ConnectTimeoutError'
+            }
+          }
         rescue HTTPClient::SendTimeoutError
           {
             :meta => {

--- a/lib/aftership/v4/base.rb
+++ b/lib/aftership/v4/base.rb
@@ -15,7 +15,9 @@ module AfterShip
         @body = body
         @client = HTTPClient.new
 
-        @client.send_timeout = AfterShip.configuration.timeout
+        @client.connect_timeout = AfterShip.configuration.connect_timeout
+        @client.send_timeout = AfterShip.configuration.send_timeout
+        @client.receive_timeout = AfterShip.configuration.receive_timeout
       end
 
       def call

--- a/lib/aftership/v4/configuration.rb
+++ b/lib/aftership/v4/configuration.rb
@@ -1,19 +1,25 @@
 module AfterShip
   module V4
     class Configuration
-      attr_accessor :api_endpoint, :api_key
-      attr_writer :timeout
+      attr_writer :connect_timeout, :send_timeout, :receive_timeout
 
       def initialize
         @api_endpoint = 'https://api.aftership.com'
-        @timeout = 3
         @headers = { 'Content-Type' => 'application/json' }
+        @connect_timeout = @receive_timeout = 500 # milliseconds
+        @send_timeout = 1000 # milliseconds
       end
 
-      def timeout
-        return 0 unless @timeout
+      def connect_timeout
+        to_seconds(@connect_timeout)
+      end
 
-        @timeout.to_f / 1000
+      def send_timeout
+        to_seconds(@send_timeout)
+      end
+
+      def receive_timeout
+        to_seconds(@receive_timeout)
       end
 
       def headers
@@ -22,6 +28,12 @@ module AfterShip
 
       def headers= h
         @headers.merge!(h)
+      end
+
+      private
+
+      def to_seconds(milliseconds)
+        milliseconds.to_f / 1000
       end
     end
   end


### PR DESCRIPTION
These changes will allow us to have more flexibility when setting the timeouts for the clients (in `cw-shipping`):

```ruby
# config/initializers/aftership.rb
require 'aftership'

AfterShip.configure do |config|
  config.api_key = CW::SDK::Config.aftership_api_key
  config.connect_timeout = 100 # ms
  config.send_timeout = 300 # ms
  config.receive_timeout = 300 # ms
end
```

We can be a bit more strict with the timeouts here from the beginning and relax the timeouts on a need-to basis.